### PR TITLE
Added ENV config var support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,6 +137,7 @@ func Get(fs *pflag.FlagSet) (*Config, error) {
 
 func newDefaultViper() *viper.Viper {
 	v := viper.New()
+
 	v.SetDefault("default.protoPath", []string{""})
 	v.SetDefault("default.protoFile", []string{""})
 	v.SetDefault("default.package", "")
@@ -167,6 +168,13 @@ func newDefaultViper() *viper.Viper {
 	v.SetDefault("request.certFile", "")
 	v.SetDefault("request.certKeyFile", "")
 	v.SetDefault("request.web", false)
+
+	v.SetEnvPrefix("EVANS")
+	v.SetEnvKeyReplacer(strings.NewReplacer(
+		".", "_", // for nested values
+	))
+	v.AllowEmptyEnv(true)
+	v.AutomaticEnv()
 
 	return v
 }


### PR DESCRIPTION
Added support for ENVAR injection. Variable names map to configuration options with an `EVANS_` prefix, all caps, and with underscores instead of dots.

This change was written so as to have the environment variables affect the default configuration option values generated by the config output workflows. 